### PR TITLE
[G2M] GenericMap - allow NavigationControl/MapContext to bypass onViewStateChange handler

### DIFF
--- a/src/components/generic-map.js
+++ b/src/components/generic-map.js
@@ -120,6 +120,9 @@ const Map = ({
         }}
         onViewStateChange={o => {
           const { viewState, interactionState } = o
+          if (!interactionState) {
+            return // "hack" to allow MapContext/NavigationControl take over
+          }
           const{ isDragging, isZooming, isPanning, isRotating } = interactionState
           // makes tooltip info disappear when we click and zoom in on a location
           setHoverInfo(null)


### PR DESCRIPTION
though, the orientation control doesn't seem to work

https://user-images.githubusercontent.com/2837532/195933404-25335513-aec8-4f26-b3f1-a3da04b426de.mov

