### PR TITLE
[G2M] Legend - fix Layer Title alignment & Icon container to centre always with the legend symbols

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eqworks/react-maps",
-  "version": "0.11.8",
+  "version": "0.11.9",
   "description": "React maps",
   "author": "EQ Inc.",
   "license": "UNLICENSED",

--- a/src/components/legend/index.js
+++ b/src/components/legend/index.js
@@ -67,10 +67,7 @@ const Legend = ({
   // const [activeLegend, setActiveLegend] = useState(0)
   // const handleLegendChange = () => setActiveLegend(o => o === legends.length - 1 ? 0 : o + 1)
 
-  let font = ''
-  if (layerTitleRef.current) {
-    font = getCanvasFont(layerTitleRef.current)
-  }
+  const font = getCanvasFont(layerTitleRef.current)
 
   const maxLegendWidth = useMemo(() =>
     Math.max(

--- a/src/components/legend/legend-item.js
+++ b/src/components/legend/legend-item.js
@@ -8,7 +8,6 @@ import LegendSymbol from './legend-symbol'
 import { getLegendItemElements, getValueRangeWidth, getLegendItemDimensions } from './utils'
 import {
   LEGEND_TYPE,
-  LEGEND_SYMBOL_WIDTH,
   MIN_LEGEND_LINE_WIDTH,
   LEGEND_DOTS,
   LEGEND_RADIUS_SIZE,
@@ -172,10 +171,10 @@ const LegendItem = ({ legendItemProps }) => {
     }
     return Math.max(
       MIN_LEGEND_LINE_WIDTH,
-      LEGEND_SYMBOL_WIDTH[legendSize] + rightTextOffset - lineTextMaxWidth - LEGEND_TEXT_GAP,
+      legendElemWidth + rightTextOffset - lineTextMaxWidth - LEGEND_TEXT_GAP,
     )
   }
-  , [rightTextOffset, lineTextMaxWidth, legendElemWidth, legendSize])
+  , [rightTextOffset, lineTextMaxWidth, legendElemWidth])
 
   return (
     <>
@@ -183,7 +182,7 @@ const LegendItem = ({ legendItemProps }) => {
         <LegendBody id='legend-body' padding={paddingLeft}>
           <LegendTitle
             id='legend-title'
-            legendelemwidth={LEGEND_SYMBOL_WIDTH[legendSize]}
+            legendelemwidth={legendElemWidth}
             marginbottom={legendTitleMarginBottom}
             marginleft={legendElementsLeftMargin + symbolContainerLeftMargin}
           >
@@ -248,7 +247,10 @@ const LegendItem = ({ legendItemProps }) => {
         </LegendBody>
       )}
       {min === undefined && max === undefined && type === LEGEND_TYPE.icon && (
-        <LegendSymbolContainer>
+        <LegendSymbolContainer
+          legendelemwidth={legendElemWidth}
+          symbolcontainerleftmargin={symbolMarginLeft + paddingLeft}
+        >
           <LegendSymbol symbolProps={{ max, type, legendSize, ...symbolProps }} />
         </LegendSymbolContainer>
       )}

--- a/src/components/legend/utils.js
+++ b/src/components/legend/utils.js
@@ -189,6 +189,9 @@ const getCssStyle = (element, prop) => window.getComputedStyle(element, null).ge
  * @returns { string } - concatenated string of font weight, size, & family for an element
  */
 export const getCanvasFont = (el = document.documentElement) => {
+  if (!el) {
+    return ''
+  }
   const fontWeight = getCssStyle(el, 'font-weight') || 'normal'
   const fontSize = getCssStyle(el, 'font-size') || '16px'
   const fontFamily = getCssStyle(el, 'font-family').split(',')[0] || 'Times New Roman'

--- a/src/components/legend/utils.js
+++ b/src/components/legend/utils.js
@@ -26,9 +26,9 @@ export const getLegendItemElements = ({ legendItemProps }) => {
     legendSize,
   } = legendItemProps
 
-  const legendElemWidth = max !== min ?
-    LEGEND_SYMBOL_WIDTH[legendSize] :
-    LEGEND_SYMBOL_WIDTH.zero
+  const legendElemWidth = min === max && min === 0 ?
+    LEGEND_SYMBOL_WIDTH.zero :
+    LEGEND_SYMBOL_WIDTH[legendSize]
   const title = formatLegendTitle(keyAliases?.[label] || formatDataKey(label))
 
   const [minValue, maxValue] = formatDataValue?.[label] ?
@@ -156,4 +156,42 @@ export const getLegendItemDimensions = ({
   }
 
   return { textContainerWidth, symbolContainerLeftMargin, textContainerLeftMargin }
+}
+
+/**
+ * getTextWidth - uses canvas.measureText to compute and return the width of the given text of given font in pixels.
+ * @param { string } text - the text to be rendered.
+ * @param { string } font - the css font descriptor that text is to be rendered with (e.g. 'bold 14px verdana').
+ * @returns { number } - the width of the text in px
+ *
+ * @see https://stackoverflow.com/questions/118241/calculate-text-width-with-javascript/21015393#21015393
+ */
+export const getTextWidth = (text, font) => {
+  // re-use canvas object for better performance
+  const canvas = getTextWidth.canvas || (getTextWidth.canvas = document.createElement('canvas'))
+  const context = canvas.getContext('2d')
+  context.font = font
+  const metrics = context.measureText(text)
+  return metrics.width
+}
+
+/**
+ * getCssStyle - gets css styling for an element
+ * @param { element } element - an element
+ * @param { string } prop - the css property to retrieve
+ * @returns { number || string } - the value of a css property
+ */
+const getCssStyle = (element, prop) => window.getComputedStyle(element, null).getPropertyValue(prop)
+
+/**
+ * getCanvasFont - gets font weight, size, & family for an element
+ * @param { element } el - an element
+ * @returns { string } - concatenated string of font weight, size, & family for an element
+ */
+export const getCanvasFont = (el = document.documentElement) => {
+  const fontWeight = getCssStyle(el, 'font-weight') || 'normal'
+  const fontSize = getCssStyle(el, 'font-size') || '16px'
+  const fontFamily = getCssStyle(el, 'font-family').split(',')[0] || 'Times New Roman'
+
+  return `${fontWeight} ${fontSize} ${fontFamily}`
 }


### PR DESCRIPTION
https://www.notion.so/eqproduct/Fix-alignment-of-the-Icon-legend-according-to-the-latest-changes-in-Legend-component-0b5f2b2b1ee44f01bc88cd76cc904a20?pvs=4

**Changes:**

### Legend
- adjust styling for `LayerTitle `so the component is centred vertically with the symbol containers in the legend
- added width & margin to the Icon `LegendSymbolContainer `to align `Icons` also with the centre of all symbols in the legend

**Screenshots:**
<img width="170" alt="Screen Shot 2023-02-09 at 8 55 08 PM" src="https://user-images.githubusercontent.com/41120953/217980659-71953bef-fca9-4389-ae85-a7eb6522e639.png">
<img width="170" alt="Screen Shot 2023-02-09 at 8 55 00 PM" src="https://user-images.githubusercontent.com/41120953/217980672-b8874eaa-a48e-4182-9b72-b5ca33a3f65d.png">
<img width="230" alt="Screen Shot 2023-02-09 at 5 31 47 PM" src="https://user-images.githubusercontent.com/41120953/217980695-6f1568aa-5f8e-45e2-b6b8-a622b49d1fff.png">

<img width="230" alt="Screen Shot 2023-02-09 at 5 29 16 PM" src="https://user-images.githubusercontent.com/41120953/217980709-c6d08a21-1718-49ce-b3c5-4693742b3e0e.png">

