### PR TITLE
[G2M] Fix legend title container max-width for zero values

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eqworks/react-maps",
-  "version": "0.11.9",
+  "version": "0.11.10",
   "description": "React maps",
   "author": "EQ Inc.",
   "license": "UNLICENSED",

--- a/src/components/legend/legend-item.js
+++ b/src/components/legend/legend-item.js
@@ -13,6 +13,7 @@ import {
   LEGEND_RADIUS_SIZE,
   LEGEND_TITLE_BOTTOM_MARGIN,
   LEGEND_TEXT_GAP,
+  LEGEND_SYMBOL_WIDTH,
 } from '../../constants'
 
 
@@ -182,7 +183,7 @@ const LegendItem = ({ legendItemProps }) => {
         <LegendBody id='legend-body' padding={paddingLeft}>
           <LegendTitle
             id='legend-title'
-            legendelemwidth={legendElemWidth}
+            legendelemwidth={LEGEND_SYMBOL_WIDTH[legendSize]}
             marginbottom={legendTitleMarginBottom}
             marginleft={legendElementsLeftMargin + symbolContainerLeftMargin}
           >


### PR DESCRIPTION
https://www.notion.so/eqproduct/Fix-legend-title-container-max-width-for-zero-values-4d5223eb99654a4186deedd19300d84d?pvs=4

**Changes:**

#### LegendItem
- restores the previous changed value for max-width for `LegendTitle`

Before:
<img width="66" alt="Screen Shot 2023-02-10 at 3 06 11 PM" src="https://user-images.githubusercontent.com/41120953/218188203-a55fdca2-6b32-49b0-9311-64de00420f20.png">

Fix:
<img width="91" alt="Screen Shot 2023-02-10 at 3 07 01 PM" src="https://user-images.githubusercontent.com/41120953/218188223-300a4e78-fdc8-4673-801e-dfee6335bcf1.png">

[Story](https://60f06c1c5a1772003b824d76-upnvhqrymb.chromatic.com/?path=/story/locus-ql-report--vwi-zero-min-and-max-values-for-radius-and-radiusfill-legend)
