### PR TITLE
[G2M] Locus map - adjust text layer geom config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eqworks/react-maps",
-  "version": "0.11.10",
+  "version": "0.11.11",
   "description": "React maps",
   "author": "EQ Inc.",
   "license": "UNLICENSED",

--- a/src/components/locus-map/constants.js
+++ b/src/components/locus-map/constants.js
@@ -173,10 +173,12 @@ export const LAYER_CONFIGURATIONS = {
     dataPropertyAccessor: d => d,
     geometry: {
       propName: 'getPosition',
-      propFn: ({ longitude, latitude, geometryAccessor = d => d }) => d =>
-        d.type === 'Feature' && d.geometry?.type === GEOJSON_TYPES.point ?
-          d.geometry.coordinates :
-          [geometryAccessor(d)[longitude], geometryAccessor(d)[latitude]],
+      propFn: ({ longitude = 'longitude', latitude = 'latitude', geometryAccessor = d => d }) => d => {
+        if (d.type === 'Feature' && d.geometry?.type === GEOJSON_TYPES.point) {
+          return d.geometry.coordinates
+        }
+        return [geometryAccessor(d)[longitude], geometryAccessor(d)[latitude]]
+      },
       longitude: { type: 'number' },
       latitude: { type: 'number' },
     },

--- a/stories/locus.stories.js
+++ b/stories/locus.stories.js
@@ -157,8 +157,6 @@ const polygonTextGeoJSONLayerConfig = {
   dataId: 'regionGeojson-123',
   dataPropertyAccessor: d => d.properties,
   geometry: {
-    longitude: 'longitude',
-    latitude: 'latitude',
     geometryAccessor: d => d.properties,
   },
   visualizations: {
@@ -510,8 +508,6 @@ const textGeoJSONMVTConfig = {
   dataPropertyAccessor: d => d.properties,
   geometry: {
     geoKey: 'geo_ca_fsa',
-    longitude: 'longitude',
-    latitude: 'latitude',
     geometryAccessor: d => d.properties,
   },
   visualizations: {


### PR DESCRIPTION
https://www.notion.so/eqproduct/Fix-selection-of-visualizations-for-map-with-user-value-controls-on-top-when-filtering-zero-data-bcc52a123abc4aa48f84fe8837ed5929?pvs=4

**Changes:**

### LocusMap

- added default coordinates keys for text layer

**Test stories:**
https://60f06c1c5a1772003b824d76-wbbkwkrkrm.chromatic.com/?path=/story/locus-map--polygon-geo-json-layer
https://60f06c1c5a1772003b824d76-wbbkwkrkrm.chromatic.com/?path=/story/locus-map--scatterplot-layer-scheme-colour
https://60f06c1c5a1772003b824d76-wbbkwkrkrm.chromatic.com/?path=/story/locus-map--geo-json-layer-scheme-colour
https://60f06c1c5a1772003b824d76-wbbkwkrkrm.chromatic.com/?path=/story/locus-map--geo-jsonmvt-label-layer